### PR TITLE
Fix a weird completion lookup.

### DIFF
--- a/bash-cli.inc.sh
+++ b/bash-cli.inc.sh
@@ -36,7 +36,7 @@ function bcli_entrypoint() {
 
     local cli_entrypoint;
     cli_entrypoint=$(basename "$0")
-    
+
     # Locate the correct command to execute by looking through the app directory
     # for folders and files which match the arguments provided on the command line.
     local cmd_file;
@@ -120,7 +120,7 @@ function bcli_help() {
 
     local cli_entrypoint;
     cli_entrypoint=$(basename "$1")
-    
+
     # If we don't have any additional help arguments, then show the app's
     # header as well.
     if [ $# == 0 ]; then
@@ -142,7 +142,7 @@ function bcli_help() {
     # commands in that directory along with its help content.
     if [[ -d "$help_file" ]]; then
         echo -e "${COLOR_GREEN}$cli_entrypoint ${COLOR_CYAN}${*:2:$((help_arg_start-1))} ${COLOR_NORMAL}"
-        
+
         # If there's a help file available for this directory, then show it.
         if [[ -f "$help_file/.help" ]]; then
             cat "$help_file/.help"
@@ -219,6 +219,13 @@ function bcli_bash_completions() {
         cmd_file=$(dirname "$cmd_file")
     fi
 
+    # If cursor is on the end of command we want to get a name of current file/directory
+    # and don't look inside folder.
+    if [[ $curr_arg = $(basename $cmd_file) ]]; then
+        COMPREPLY=($(basename $cmd_file))
+        return
+    fi
+
     # If we found a command, then suggest the `--help` argument
     # TODO: Add parsing of .usage files for this
     if [[ -f "$cmd_file" ]]; then
@@ -241,7 +248,7 @@ function bcli_bash_completions() {
             # shellcheck disable=SC2207 # Using this as alternatives are not cross-platform or introduce dependencies
             opts=("${opts[@]}" $(basename "$file"))
         done < <(find "$cmd_file"/ -maxdepth 1 ! -path "$cmd_file"/ ! -iname '*.*' -print0)
-        
+
         IFS="
         "
         # shellcheck disable=SC2207 # Using this as alternatives are not cross-platform or introduce dependencies

--- a/bash-cli.inc.sh
+++ b/bash-cli.inc.sh
@@ -221,8 +221,9 @@ function bcli_bash_completions() {
 
     # If cursor is on the end of command we want to get a name of current file/directory
     # and don't look inside folder.
-    if [[ $curr_arg = $(basename $cmd_file) ]]; then
-        COMPREPLY=($(basename $cmd_file))
+    if [[ $curr_arg = $(basename "$cmd_file") ]]; then
+        # shellcheck disable=SC2207 # Using this as alternatives are not cross-platform or introduce dependencies
+        COMPREPLY=($(basename "$cmd_file"))
         return
     fi
 


### PR DESCRIPTION
If I have a cursor at the end of command suggestion doesn't work:

`cli command[tab-tab]` does nothing, but should complete "command". Note: no space after `command`, cursor just right behind "d"
`cli command [tab-tab]` returns list of possible sub-commands.

This MR is fixing this. I spend couple hours troubleshooting that. I even started rewriting whole func but ended up almost with the same logic. So it's probably not the best solution.

**The problem is that:**
if cursor is on any word `$curr_arg` will have is as value e.g:

cli command[]<-- $curr_arg='command' later it wants to `COMPREPLY=($(compgen -W '--help' -- "$curr_arg"))`

so It the same as:
```sh
COMPREPLY=($(compgen -W '--help' -- "command")) 
```
 aaand nothing happens.

And the same with directories:

```sh
...
elif [ -d "$cmd_file" ]; then
....

COMPREPLY=($(compgen -W "$(printf '%s\n' "${opts[@]}")" -- "$curr_arg"))
```

cmd_file is `./app/command` as it exists `$opts` will be `(create  help    rm)` and $curr_arg='command'
So no completion is happened here as well.
