### PR TITLE
fix: app/example/completion.usage should contain explanatory text line

### DIFF
--- a/app/example/completion.usage
+++ b/app/example/completion.usage
@@ -1,2 +1,1 @@
-#!/usr/bin/env bash
-echo -e "\033[36mTODO\033[39m: Implement this command"
+ARGS


### PR DESCRIPTION
completion.usage contained a bash script - but this file should contain the short help line for the "example completion" command.