### PR TITLE
removed perl dependency: Use realpath utility from GNU coreutils instead

### DIFF
--- a/app/uninstall.sh
+++ b/app/uninstall.sh
@@ -4,6 +4,18 @@ if [ $# == 0 ]; then
     exit 3
 fi
 
+realpath() {
+    if [ -x "$( which realpath )" ]
+    then
+        # call the realpath utility if installed
+        "$( which realpath )" "$1"
+    else
+        # on MacOS there is no realpath utility on a default installation
+        # -> use fallback to perl
+        perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    fi
+}
+
 APP_DIR=$(pwd)
 
 if [[ -f "$APP_DIR/.bash_cli" ]]; then

--- a/app/uninstall.sh
+++ b/app/uninstall.sh
@@ -22,9 +22,9 @@ FOLDER="${2-"/usr/bin"}"
 if [[ ! -f "$FOLDER/$NAME" ]]; then
     >&2 echo -e "\033[31mCommand \033[36m$1\033[31m did not exist in \033[36m$2\033[39m"
     exit 1
-fi
+f
 
-LN_PATH=$(perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$FOLDER/$NAME")
+LN_PATH=$(realpath "$FOLDER/$NAME")
 
 if [[ "$LN_PATH" != "$APP_DIR/cli" ]]; then
     >&2 echo -e "\033[31mCommand \033[36m$1\033[31m doesn't resolve to this project\033[39m"

--- a/app/uninstall.sh
+++ b/app/uninstall.sh
@@ -34,7 +34,7 @@ FOLDER="${2-"/usr/bin"}"
 if [[ ! -f "$FOLDER/$NAME" ]]; then
     >&2 echo -e "\033[31mCommand \033[36m$1\033[31m did not exist in \033[36m$2\033[39m"
     exit 1
-f
+fi
 
 LN_PATH=$(realpath "$FOLDER/$NAME")
 

--- a/bash-cli.inc.sh
+++ b/bash-cli.inc.sh
@@ -13,7 +13,7 @@ COLOR_DARK_GRAY="\033[38m"
 COLOR_NORMAL="\033[39m"
 
 function bcli_resolve_path() {
-    perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    realpath "$1"
 }
 
 function bcli_trim_whitespace() {

--- a/bash-cli.inc.sh
+++ b/bash-cli.inc.sh
@@ -12,7 +12,8 @@ COLOR_LIGHT_GRAY="\033[37m"
 COLOR_DARK_GRAY="\033[38m"
 COLOR_NORMAL="\033[39m"
 
-realpath() {
+
+function bcli_resolve_path() {
     if [ -x "$( which realpath )" ]
     then
         # call the realpath utility if installed
@@ -22,10 +23,6 @@ realpath() {
         # -> use fallback to perl
         perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
     fi
-}
-
-function bcli_resolve_path() {
-    realpath "$1"
 }
 
 function bcli_trim_whitespace() {

--- a/bash-cli.inc.sh
+++ b/bash-cli.inc.sh
@@ -12,6 +12,18 @@ COLOR_LIGHT_GRAY="\033[37m"
 COLOR_DARK_GRAY="\033[38m"
 COLOR_NORMAL="\033[39m"
 
+realpath() {
+    if [ -x "$( which realpath )" ]
+    then
+        # call the realpath utility if installed
+        "$( which realpath )" "$1"
+    else
+        # on MacOS there is no realpath utility on a default installation
+        # -> use fallback to perl
+        perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    fi
+}
+
 function bcli_resolve_path() {
     realpath "$1"
 }

--- a/cli
+++ b/cli
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+realpath() {
+    if [ -x "$( which realpath )" ]
+    then
+        # call the realpath utility if installed
+        "$( which realpath )" "$1"
+    else
+        # on MacOS there is no realpath utility on a default installation
+        # -> use fallback to perl
+        perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    fi
+}
+
 ROOT_DIR=$(dirname "$(realpath "$0")")
 
 # shellcheck source=./bash-cli.inc.sh

--- a/cli
+++ b/cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ROOT_DIR=$(dirname "$(perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$0")")
+ROOT_DIR=$(dirname "$(realpath "$0")")
 
 # shellcheck source=./bash-cli.inc.sh
 . "$ROOT_DIR/bash-cli.inc.sh"

--- a/complete
+++ b/complete
@@ -3,7 +3,7 @@
 
 function _bash_cli() {
     local root_dir;
-    root_dir=$(dirname "$(perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$(which "${COMP_WORDS[0]}")")")
+    root_dir=$(dirname "$(realpath "$(which "${COMP_WORDS[0]}")")")
     
     # shellcheck source=./bash-cli.inc.sh
     . "$root_dir/bash-cli.inc.sh"

--- a/complete
+++ b/complete
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 
+# this file is sourced by /etc/bash_completion.d/* and therefore should not shadow
+# any existing commands in the shell -> add bcli_ prefix to realpath-helper function here
+bcli_realpath() {
+    if [ -x "$( which realpath )" ]
+    then
+        # call the realpath utility if installed
+        "$( which realpath )" "$1"
+    else
+        # on MacOS there is no realpath utility on a default installation
+        # -> use fallback to perl
+        perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    fi
+}
 
 function _bash_cli() {
     local root_dir;
-    root_dir=$(dirname "$(realpath "$(which "${COMP_WORDS[0]}")")")
+    root_dir=$(dirname "$(bcli_realpath "$(which "${COMP_WORDS[0]}")")")
     
     # shellcheck source=./bash-cli.inc.sh
     . "$root_dir/bash-cli.inc.sh"

--- a/help
+++ b/help
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+realpath() {
+    if [ -x "$( which realpath )" ]
+    then
+        # call the realpath utility if installed
+        "$( which realpath )" "$1"
+    else
+        # on MacOS there is no realpath utility on a default installation
+        # -> use fallback to perl
+        perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$1"
+    fi
+}
+
 ROOT_DIR=$(dirname "$(realpath "$0")")
 
 # shellcheck source=./bash-cli.inc.sh

--- a/help
+++ b/help
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ROOT_DIR=$(dirname "$(perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$0")")
+ROOT_DIR=$(dirname "$(realpath "$0")")
 
 # shellcheck source=./bash-cli.inc.sh
 . "$ROOT_DIR/bash-cli.inc.sh"


### PR DESCRIPTION
Currently an inline perl script is used to "determine the absolute path for a relative path". The very same line

perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$FOLDER/$NAME"

can be replaced by a much more reader-friendly call of the realpath utility from the GNU coreutils:

realpath "$FOLDER/$NAME"

( https://www.gnu.org/software/coreutils/manual/html_node/realpath-invocation.html#realpath-invocation )

Changing this helps to understand what is happening and also removes the heavy-weighted dependency to the perl interpreter which was only needed for this single purpose and is not used anywhere else in the repository.

